### PR TITLE
Go back to using Xaptum's fork of WolfSSL.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
     packages = ['xaptum',
                 'xaptum.client'],
     install_requires = ['xtt>=0.9.2-0',
-                        'wolfssl>=3.14.0-1']
+                        'wolfssl_with_ed25519>=3.14.4-1']
     )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 setup(
     name    = 'xaptum-client',
-    version = '0.3.0',
+    version = '0.3.1',
     description = 'Client libraries for the Xaptum ENF',
     author = 'Xaptum, Inc',
     author_email = 'sales@xaptum.com',


### PR DESCRIPTION
In addition to fixing their Ed25519 support,
our fork also fixes some other memory corruption bugs in the WolfSSl
code.